### PR TITLE
Fixed set_data issue.(duped notification when using notify_change)

### DIFF
--- a/lib/win32/clipboard.rb
+++ b/lib/win32/clipboard.rb
@@ -44,9 +44,7 @@ module Win32
     def self.empty
       begin
         open
-        unless EmptyClipboard()
-          raise SystemCallError.new('EmptyClipboard', FFI.errno)
-        end
+        clear_if_already_opened
       ensure
         close
       end
@@ -147,8 +145,8 @@ module Win32
     #
     def self.set_data(clip_data, format = TEXT)
       begin
-        clear
         open
+        clear_if_already_opened
 
         # NULL terminate text or strip header of bitmap file
         case format
@@ -342,6 +340,14 @@ module Win32
     def self.close
       unless CloseClipboard()
         raise SystemCallError.new('CloseClipboard', FFI.errno)
+      end
+    end
+
+    # Clear the clipboard that is already opened
+    #
+    def self.clear_if_already_opened
+      unless EmptyClipboard()
+        raise SystemCallError.new('EmptyClipboard', FFI.errno)
       end
     end
 


### PR DESCRIPTION
# steps
1. Run this code.

``` ruby:test.rb
require 'win32/clipboard'

@count = 0
Thread.start do
  Win32::Clipboard.notify_change{@count += 1; puts "count:#{@count}"}
end

sleep(1)
Win32::Clipboard.set_data('foo')
sleep(1)
```

Results:

```
count:1
count:2
```
# problem

It should be only "count:1",
but "count:1" and "count:2".

I'm using the following:

Windows 7 (x64)
Ruby 2.0.0p353 (2013-11-22)[x64-mingw32]
win32/clipboard 0.6.2
