### PR TITLE
Fixed notify_change issue.(clipboard chain broken)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,6 +51,12 @@ namespace :test do
     t.verbose = true
     t.test_files = FileList['test/test_image_clipboard.rb']
   end
+
+  Rake::TestTask.new(:chain) do |t|
+    t.warning = true
+    t.verbose = true
+    t.test_files = FileList['test/test_clipboard_chain.rb']
+  end
 end
 
 task :default => 'test:all'

--- a/lib/win32/clipboard.rb
+++ b/lib/win32/clipboard.rb
@@ -272,6 +272,11 @@ module Win32
 
       wnd_proc = FFI::Function.new(:uintptr_t, [:uintptr_t, :uint, :uintptr_t, :uintptr_t]) do |hwnd, umsg, wparam, lparam|
         case umsg
+           when WM_DESTROY
+             next_viewer = GetWindowLongPtr(hwnd, GWL_USERDATA)
+             ChangeClipboardChain(hwnd, next_viewer)
+             PostQuitMessage(0)
+             rv = 0
            when WM_DRAWCLIPBOARD
              yield unless @first_notify
              next_viewer = GetWindowLongPtr(hwnd, GWL_USERDATA)
@@ -280,8 +285,9 @@ module Win32
              end
              rv = 0
            when WM_CHANGECBCHAIN
-             yield unless @first_notify
+             next_viewer = GetWindowLongPtr(hwnd, GWL_USERDATA)
              next_viewer = lparam if next_viewer == wparam
+             SetWindowLongPtr(hwnd, GWL_USERDATA, next_viewer)
              if next_viewer != 0
                PostMessage(next_viewer, umsg, wparam, lparam)
              end
@@ -306,6 +312,8 @@ module Win32
       end
 
       SetWindowLongPtr(handle, GWL_USERDATA, next_viewer)
+
+      ObjectSpace.define_finalizer(self, proc{self.close_window(handle)})
 
       msg = FFI::MemoryPointer.new(:char, 100)
 
@@ -420,6 +428,12 @@ module Win32
       }
 
       array
+    end
+
+    # Close a window.(for self.notify_change)
+    #
+    def self.close_window(handle)
+      SendMessage(handle, WM_CLOSE, 0, 0)
     end
   end
 end

--- a/lib/win32/windows/constants.rb
+++ b/lib/win32/windows/constants.rb
@@ -1,6 +1,8 @@
 module Windows
   module Constants
     GHND = 0x0042
+    WM_DESTROY = 0x0002
+    WM_CLOSE = 0x0010
     WM_DRAWCLIPBOARD = 0x0308
     WM_CHANGECBCHAIN = 0x030D
     GWL_USERDATA = -21

--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -24,6 +24,7 @@ module Windows
 
     ffi_lib :user32
 
+    attach_function :ChangeClipboardChain, [:hwnd, :hwnd], :bool
     attach_function :CloseClipboard, [], :bool
     attach_function :CountClipboardFormats, [], :int
     attach_function :CreateWindowEx, :CreateWindowExA, [:dword, :string, :string, :dword, :int, :int, :int, :int, :hwnd, :hmenu, :hinstance, :pointer], :hwnd
@@ -37,9 +38,11 @@ module Windows
     attach_function :OpenClipboard, [:hwnd], :bool
     attach_function :PeekMessage, :PeekMessageA, [:pointer, :hwnd, :uint, :uint, :uint], :bool
     attach_function :PostMessage, :PostMessageA, [:hwnd, :uint, :uintptr_t, :uintptr_t], :bool
+    attach_function :PostQuitMessage, :PostQuitMessage, [:uint], :void
     attach_function :RegisterClipboardFormat, :RegisterClipboardFormatA, [:string], :uint
     attach_function :SetClipboardData, [:uint, :handle], :handle
     attach_function :SetClipboardViewer, [:hwnd], :hwnd
+    attach_function :SendMessage, :SendMessageA, [:hwnd, :uint, :uintptr_t, :uintptr_t], :bool
     attach_function :TranslateMessage, [:pointer], :bool
 
     # Use Long on 32-bit Ruby, LongPtr on 64-bit Ruby

--- a/test/lock.rb
+++ b/test/lock.rb
@@ -1,0 +1,18 @@
+require 'timeout'
+require 'tmpdir'
+
+def lock(&block)
+  Timeout::timeout(5) do
+    open(File.join(Dir.tmpdir, 'ruby-win32-clipboard.lock'), 'w') do |f|
+      begin
+        f.flock(File::LOCK_EX)
+        yield
+      ensure
+        f.flock(File::LOCK_UN)
+      end
+    end
+  end
+rescue Timeout::Error
+  raise 'Lock(timeout)'
+end
+

--- a/test/notify.rb
+++ b/test/notify.rb
@@ -1,0 +1,24 @@
+require 'win32/clipboard'
+require File.join(File.dirname(__FILE__), 'lock')
+
+include Win32
+
+def write
+  data = ''
+  lock do
+    data = Clipboard.data
+  end
+
+  begin
+    STDOUT.puts data
+    STDOUT.flush
+  rescue => e
+    puts $!
+  end
+  if data == ARGV[0]
+    exit
+  end
+end
+
+Clipboard.notify_change {write}
+

--- a/test/test_clipboard_chain.rb
+++ b/test/test_clipboard_chain.rb
@@ -1,0 +1,128 @@
+# encoding: utf-8
+###########################################################################
+# test_clipboard_chain.rb
+#
+# Test suite for the win32-clipboard library(only clipboard chain).
+###########################################################################
+require 'test-unit'
+require 'win32/clipboard'
+require 'timeout'
+require File.join(File.dirname(__FILE__), 'lock')
+
+include Win32
+
+class TC_Clipboard_Chain < Test::Unit::TestCase
+  test "clipboard viewer chain" do
+    begin
+      # Add clipboard viewer 1-3
+      # clipboard viewer chain: cv3 -> cv2 -> cv1
+      cv1 = ClipboardViewer.new('1')
+      puts 'Added clipboard viewer 1'
+
+      cv2 = ClipboardViewer.new('2')
+      puts 'Added clipboard viewer 2'
+
+      cv3 = ClipboardViewer.new('3')
+      puts 'Added clipboard viewer 3'
+
+      lock do
+        Clipboard.set_data('foo')
+      end
+
+      result = Clipboard.data
+      assert_equal(result, cv1.result)
+      assert_equal(result, cv2.result)
+      assert_equal(result, cv3.result)
+
+      # Remove clipboard viewer 2
+      # clipboard viewer chain: cv3 -> cv1
+      assert_not_nil(cv2.remove)
+
+      cv1.clear
+      cv3.clear
+      Clipboard.set_data('bar')
+
+      result = Clipboard.data
+      assert_equal(result, cv1.result)
+      assert_equal(result, cv3.result)
+
+      # Remove clipboard viewer 3
+      assert_not_nil(cv3.remove)
+
+      cv1.clear
+      Clipboard.set_data('foobar')
+
+      result = Clipboard.data
+      assert_equal(result, cv1.result)
+      assert_not_nil(cv1.remove)
+    ensure
+      cv1.remove
+      cv2.remove
+      cv3.remove
+    end
+  end
+
+  class ClipboardViewer
+    def initialize(key)
+      @key = key
+      @pipe = IO.popen("#{RbConfig.ruby} #{File.join(File.dirname(__FILE__), "notify.rb")} #{key}")
+      @result = nil
+      is_ready = false
+
+      @t = Thread.start do
+        begin
+          while true
+            result = @pipe.gets.chomp
+
+            if result == 'ready'
+              is_ready = true
+            else
+              @result = result
+            end
+
+            if @result == @key.chop
+              break
+            end
+          end
+        rescue => e
+          puts $!
+          puts e.backtrace
+        end
+      end
+
+      until is_ready
+        lock do
+          Clipboard.set_data('ready')
+        end
+        sleep(0.1)
+      end
+    end
+
+    def clear
+      @result = nil
+    end
+
+    def result
+      Timeout::timeout(5) do
+        until @result
+          sleep(0.1)
+        end
+      end
+      @result
+    rescue Timeout::Error
+      raise 'Cannot get result.(Timeout)'
+    end
+
+    def remove
+      return unless @t.alive?
+      lock do
+        Clipboard.set_data(@key)
+      end
+      ret = @t.join(3)
+      if ret
+        @pipe.close
+      end
+      ret
+    end
+  end
+end


### PR DESCRIPTION
# steps
#### 1.Run this code.

test1.rb

``` ruby
require 'win32/clipboard'

Win32::Clipboard.notify_change{puts "foo"}
```
#### 2. Run this code.

test2.rb:

``` ruby
require 'win32/clipboard'

Win32::Clipboard.notify_change{puts "bar"}
```
#### 3. Kill a process of "ruby test2.rb" and then copy something.
# problem

The result should be "foo", but nothing.

I'm using the following:

Windows 7 (x64)
Ruby 2.0.0p353 (2013-11-22)[x64-mingw32]
win32/clipboard 0.6.2
