### PR TITLE
Set callback proc after SetClipboardViewer is called.

### DIFF
--- a/lib/win32/clipboard.rb
+++ b/lib/win32/clipboard.rb
@@ -268,6 +268,16 @@ module Win32
       name   = 'ruby-clipboard-' + Time.now.to_s
       handle = CreateWindowEx(0, 'static', name, 0, 0, 0, 0, 0, 0, 0, 0, nil)
 
+      next_viewer = SetClipboardViewer(handle)
+
+      if next_viewer.nil?
+        raise SystemCallError.new('SetClipboardViewer', FFI.errno)
+      end
+
+      SetWindowLongPtr(handle, GWL_USERDATA, next_viewer)
+
+      ObjectSpace.define_finalizer(self, proc{self.close_window(handle)})
+
       @first_notify = true
 
       wnd_proc = FFI::Function.new(:uintptr_t, [:uintptr_t, :uint, :uintptr_t, :uintptr_t]) do |hwnd, umsg, wparam, lparam|
@@ -304,16 +314,6 @@ module Win32
       if SetWindowLongPtr(handle, GWL_WNDPROC, wnd_proc.address) == 0
         raise SystemCallError.new('SetWindowLongPtr', FFI.errno)
       end
-
-      next_viewer = SetClipboardViewer(handle)
-
-      if next_viewer.nil?
-        raise SystemCallError.new('SetClipboardViewer', FFI.errno)
-      end
-
-      SetWindowLongPtr(handle, GWL_USERDATA, next_viewer)
-
-      ObjectSpace.define_finalizer(self, proc{self.close_window(handle)})
 
       msg = FFI::MemoryPointer.new(:char, 100)
 

--- a/test/notify.rb
+++ b/test/notify.rb
@@ -3,6 +3,8 @@ require File.join(File.dirname(__FILE__), 'lock')
 
 include Win32
 
+timeout = ARGV[1].to_i
+
 def write
   data = ''
   lock do
@@ -20,5 +22,6 @@ def write
   end
 end
 
-Clipboard.notify_change {write}
-
+Timeout::timeout(timeout) do
+  Clipboard.notify_change {write}
+end


### PR DESCRIPTION
From issue #8

Set callback proc after SetClipboardViewer is called.
Fixed JRuby hangs in test:chain.
